### PR TITLE
fixed bug in scrollToError functionality formValidation.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "formValidation",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "A modular form validation plugin, free of third-party dependencies and built on top of native HTML5 validation.",
     "keywords": [
         "DEGJS",

--- a/src/formValidation.js
+++ b/src/formValidation.js
@@ -109,7 +109,7 @@ const formValidation = (formEl, options = {}) => {
 							}, submitForm);
 						} else {
 							if (settings.scrollToErrorOnSubmit) {
-								const errorEl = testResults[0].field.errorEl;
+								const errorEl = testResults.find(result => result.valid === false).field.fieldEl;
 								scrollToError(errorEl, settings.scrollToSpeed, settings.scrollToEasing);
 							}
 							processCallback(settings.onFormValidationError, {


### PR DESCRIPTION
line 111 of formValidation.js

scrollTo functionality was scrolling to first input in testResults instead of the first invalid field. additionally it was looking for errorEl that didn't exist.

changed functionality to scroll to the first invalid fieldEl in testResults